### PR TITLE
Correct spelling mistake

### DIFF
--- a/MovingAverageFilter.cpp
+++ b/MovingAverageFilter.cpp
@@ -1,9 +1,9 @@
 /*
 https://github.com/sebnil/Moving-Avarage-Filter--Arduino-Library-
 */
-#include "MovingAvarageFilter.h"
+#include "MovingAverageFilter.h"
 
-MovingAvarageFilter::MovingAvarageFilter(unsigned int newDataPointsCount) {
+MovingAverageFilter::MovingAverageFilter(unsigned int newDataPointsCount) {
   k = 0; //initialize so that we start to write at index 0
   if (newDataPointsCount < MAX_DATA_POINTS)
 	dataPointsCount = newDataPointsCount;
@@ -15,7 +15,7 @@ MovingAvarageFilter::MovingAvarageFilter(unsigned int newDataPointsCount) {
   }
 }
 
-float MovingAvarageFilter::process(float in) {
+float MovingAverageFilter::process(float in) {
   out = 0;
 
   values[k] = in;

--- a/MovingAverageFilter.h
+++ b/MovingAverageFilter.h
@@ -1,15 +1,15 @@
 /*
 https://github.com/sebnil/Moving-Avarage-Filter--Arduino-Library-
 */
-#ifndef MovingAvarageFilter_h
-#define MovingAvarageFilter_h
+#ifndef MovingAverageFilter_h
+#define MovingAverageFilter_h
 
 #define MAX_DATA_POINTS 20
 
-class MovingAvarageFilter {
+class MovingAverageFilter {
 public:
   //construct without coefs
-  MovingAvarageFilter(unsigned int newDataPointsCount);
+  MovingAverageFilter(unsigned int newDataPointsCount);
 
   float process(float in);
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Moving-Avarage-Filter--Arduino-Library-
+Moving-Average-Filter--Arduino-Library-
 =======================================
 
 A moving average, also called rolling average, rolling mean or running average, is a type of finite impulse response filter (FIR) used to analyze a set of datum points by creating a series of averages of different subsets of the full data set.

--- a/examples/test.ino
+++ b/examples/test.ino
@@ -1,6 +1,6 @@
-#include <MovingAvarageFilter.h>
+#include <MovingAverageFilter.h>
 
-MovingAvarageFilter movingAvarageFilter(20);
+MovingAverageFilter movingAverageFilter(20);
 
 void setup() {
 	Serial.begin(115200);
@@ -16,7 +16,7 @@ void loop() {
 		Serial.print("n= ");		// print the sample number
 		Serial.println(n, DEC);
 		Serial.println("Now calling fir...");
-		output = movingAvarageFilter.process(input);		// here we call the fir routine with the input. The value 'fir' spits out is stored in the output variable.
+		output = movingAverageFilter.process(input);		// here we call the fir routine with the input. The value 'fir' spits out is stored in the output variable.
 		Serial.print("fir presented the following value= ");
 		Serial.println(output);		// just for debugging or to understand what it does, print the output value
 	}


### PR DESCRIPTION
Change from "avarage" to "average" across library's code and example.
