### PR TITLE
Correct spelling of library name in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,4 +1,4 @@
-name=Moving-Avarage-Filter
+name=Moving-Average-Filter
 version=1.0.0
 author=Sebastian Nilsson
 maintainer=Sebastian Nilsson <sebastiannilsson.com>


### PR DESCRIPTION
Reference:
https://github.com/sebnil/Moving-Avarage-Filter--Arduino-Library-/commit/938f7d8833ee2aca4ff01d1f5cbab6b7140185cc